### PR TITLE
Fix firebase login error display

### DIFF
--- a/src/app/features/auth/login/login.component.html
+++ b/src/app/features/auth/login/login.component.html
@@ -8,20 +8,27 @@
         <mat-form-field appearance="outline">
           <mat-label>Email</mat-label>
           <input matInput type="email" formControlName="email" />
+          <mat-error *ngIf="form.get('email')?.hasError('required')">Email is required</mat-error>
+          <mat-error *ngIf="form.get('email')?.hasError('email')">Enter a valid email</mat-error>
+          <mat-error *ngIf="form.get('email')?.hasError('firebase')">{{ form.get('email')?.getError('firebase') }}</mat-error>
         </mat-form-field>
         <mat-form-field appearance="outline">
           <mat-label>Password</mat-label>
           <input matInput type="password" formControlName="password" />
+          <mat-error *ngIf="form.get('password')?.hasError('required')">Password is required</mat-error>
+          <mat-error *ngIf="form.get('password')?.hasError('minlength')">Password must be at least 6 characters</mat-error>
+          <mat-error *ngIf="form.get('password')?.hasError('firebase')">{{ form.get('password')?.getError('firebase') }}</mat-error>
         </mat-form-field>
-        <p class="error" *ngIf="error()">{{ error() }}</p>
+        
         <mat-card-actions>
-          <button mat-raised-button color="primary" type="submit" [disabled]="loading() || form.invalid">Login</button>
+          <button mat-raised-button color="primary" type="submit" [disabled]="loading()">Login</button>
           <span class="spacer"></span>
           <a routerLink="/register">Register</a>
         </mat-card-actions>
       </form>
     </mat-card-content>
   </mat-card>
+
 </div>
 
 


### PR DESCRIPTION
Map Firebase login errors to Angular Material `mat-error` for inline display and improved form validation feedback.

Previously, Firebase errors were shown as a generic paragraph. This change integrates them directly into the form fields using `mat-error`, providing more precise and contextual feedback. Additionally, the submit button's disabled state now solely reflects the loading status, with form validity checks and error marking handled programmatically on submission, preventing the button from being permanently disabled by validation errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-b06bbfe2-8330-4478-ab37-b11cdde69ffc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b06bbfe2-8330-4478-ab37-b11cdde69ffc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

