### PR TITLE
Add dark mode to ag grid tables

### DIFF
--- a/src/app/shared/theme/theme.service.ts
+++ b/src/app/shared/theme/theme.service.ts
@@ -13,6 +13,9 @@ export class ThemeService {
       const current = this.theme();
       document.body.classList.remove('theme-light', 'theme-dark');
       document.body.classList.add(current);
+      // Keep AG Grid in sync with app theme per theme modes
+      // https://www.ag-grid.com/angular-data-grid/theming-colors/#colour-schemes
+      document.body.setAttribute('data-ag-theme-mode', current === 'theme-dark' ? 'dark' : 'light');
       localStorage.setItem('app-theme', current);
     });
   }


### PR DESCRIPTION
Add dark mode support to AG Grid tables by syncing `data-ag-theme-mode` with the application's theme.

This change ensures all AG Grid tables automatically switch between light and dark themes in sync with the application's theme, leveraging AG Grid's built-in theme modes. Existing grids using `themeQuartz` will now correctly display light or dark variants based on the `body` attribute.

---
<a href="https://cursor.com/background-agent?bcId=bc-122fab34-3659-4b00-baaa-9cac8b706eee">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-122fab34-3659-4b00-baaa-9cac8b706eee">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

