### PR TITLE
Add alreadyInGroupField to modals

### DIFF
--- a/src/app/features/app/attendants/attendant-form-dialog.component.html
+++ b/src/app/features/app/attendants/attendant-form-dialog.component.html
@@ -14,6 +14,8 @@
       </mat-form-field>
     </div>
 
+    <mat-checkbox formControlName="alreadyInGroup">Already in group</mat-checkbox>
+
     <mat-form-field appearance="outline" class="w-100">
       <mat-label>Address</mat-label>
       <input matInput formControlName="address" />

--- a/src/app/features/app/attendants/attendant-form-dialog.component.ts
+++ b/src/app/features/app/attendants/attendant-form-dialog.component.ts
@@ -9,6 +9,7 @@ import { MatSelectModule } from '@angular/material/select';
 import { MatDatepickerModule } from '@angular/material/datepicker';
 import { MatNativeDateModule } from '@angular/material/core';
 import { MatIconModule } from '@angular/material/icon';
+import { MatCheckboxModule } from '@angular/material/checkbox';
 import { AttendantsService } from '../../../shared/attendants/attendants.service';
 import { Attendant, Gender } from '../../../shared/attendants/attendants.interfaces';
 import { OrganizationsService } from '../../../shared/organizations/organizations.service';
@@ -20,7 +21,7 @@ import { LoadingService } from '../../../shared/loading/loading.service';
 @Component({
   selector: 'app-attendant-form-dialog',
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, MatDialogModule, MatFormFieldModule, MatInputModule, MatButtonModule, MatSelectModule, MatDatepickerModule, MatNativeDateModule, MatIconModule],
+  imports: [CommonModule, ReactiveFormsModule, MatDialogModule, MatFormFieldModule, MatInputModule, MatButtonModule, MatSelectModule, MatDatepickerModule, MatNativeDateModule, MatIconModule, MatCheckboxModule],
   templateUrl: './attendant-form-dialog.component.html'
 })
 export class AttendantFormDialogComponent {
@@ -41,7 +42,8 @@ export class AttendantFormDialogComponent {
     phone: [''],
     dateOfBirth: [null as Date | null, [Validators.required]],
     gender: [null as Gender | null, [Validators.required]],
-    organizationId: [null as string | null]
+    organizationId: [null as string | null],
+    alreadyInGroup: [false as boolean]
   });
 
   constructor() {
@@ -59,7 +61,8 @@ export class AttendantFormDialogComponent {
         phone: (this.data as any).phone ?? '',
         dateOfBirth: dob,
         gender: this.data.gender ?? null,
-        organizationId: this.data.organizationId ?? null
+        organizationId: this.data.organizationId ?? null,
+        alreadyInGroup: (this.data as any).alreadyInGroup ?? false
       });
     }
   }
@@ -75,7 +78,8 @@ export class AttendantFormDialogComponent {
         phone: value.phone ?? '',
         dateOfBirth: value.dateOfBirth ?? null,
         gender: value.gender ?? null,
-        organizationId: value.organizationId ?? null
+        organizationId: value.organizationId ?? null,
+        alreadyInGroup: !!value.alreadyInGroup
       };
       if (this.data?.id) {
         await this.service.update(this.data.id, payload);

--- a/src/app/shared/attendants/attendants.interfaces.ts
+++ b/src/app/shared/attendants/attendants.interfaces.ts
@@ -11,6 +11,7 @@ export interface Attendant {
   dateOfBirth?: Date | null; // stored as Firestore Timestamp/Date
   gender?: Gender | null;
   organizationId?: string | null;
+  alreadyInGroup?: boolean | null;
   paymentStatus?: PaymentStatus | null;
   // map of eventId -> totalUSD and status
   eventPayments?: Record<string, { totalUSD: number; status: PaymentStatus } | undefined>;
@@ -18,4 +19,4 @@ export interface Attendant {
   updatedAt?: unknown;
 }
 
-export type NewAttendant = Pick<Attendant, 'firstName' | 'lastName' | 'address' | 'phone' | 'dateOfBirth' | 'gender' | 'organizationId'>;
+export type NewAttendant = Pick<Attendant, 'firstName' | 'lastName' | 'address' | 'phone' | 'dateOfBirth' | 'gender' | 'organizationId' | 'alreadyInGroup'>;


### PR DESCRIPTION
Add an "Already in group" checkbox field to both the create and update attendant modals.

---
<a href="https://cursor.com/background-agent?bcId=bc-5cef66cc-2f2c-4fc6-833f-3e74b0efb231">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5cef66cc-2f2c-4fc6-833f-3e74b0efb231">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

