### PR TITLE
Change attendant chart to pie

### DIFF
--- a/src/app/features/app/dashboard/dashboard.component.ts
+++ b/src/app/features/app/dashboard/dashboard.component.ts
@@ -26,10 +26,15 @@ export class DashboardComponent {
   @ViewChild('chart', { static: false }) chartEl?: ElementRef<HTMLDivElement>;
   private chart?: Highcharts.Chart;
   protected chartOptions: Highcharts.Options = {
-    chart: { type: 'column' },
+    chart: { type: 'pie' },
     title: { text: 'Attendants by Status per Event' },
-    xAxis: { categories: [] },
-    yAxis: { min: 0, title: { text: 'Attendants' } },
+    plotOptions: {
+      pie: {
+        allowPointSelect: true,
+        cursor: 'pointer',
+        dataLabels: { enabled: true, format: '{point.name}: {point.y}' }
+      }
+    },
     series: []
   };
 
@@ -54,9 +59,24 @@ export class DashboardComponent {
           });
           return { type: 'column', name: status.toUpperCase(), data } as Highcharts.SeriesColumnOptions;
         });
-        this.chartOptions = { ...this.chartOptions, xAxis: { categories }, series };
+
+        // Build pie data by aggregating totals across all events
+        const pieData = series.map(s => ({
+          name: s.name || '',
+          y: (s.data as number[]).reduce((sum, val) => sum + (typeof val === 'number' ? val : 0), 0)
+        }));
+
+        const pieSeries: Highcharts.SeriesPieOptions = {
+          type: 'pie',
+          name: 'Attendants',
+          colorByPoint: true,
+          data: pieData
+        };
+
+        this.chartOptions = { ...this.chartOptions, chart: { type: 'pie' }, series: [pieSeries] };
         this.renderChart();
-        // build table rows
+
+        // build table rows (per-event breakdown remains unchanged)
         this.statusTableRows = eventIds.map((evtId, idx) => ({
           event: categories[idx],
           unpaid: (series[0].data as number[])[idx] ?? 0,


### PR DESCRIPTION
Convert the 'Attendants by Status per Event' bar chart to a pie chart.

The pie chart now displays the aggregated distribution of attendant statuses across all events, while the accompanying table continues to show the per-event breakdown.

---
<a href="https://cursor.com/background-agent?bcId=bc-9bbe0e94-c17b-4bfd-9a3d-f15b6f1869d1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9bbe0e94-c17b-4bfd-9a3d-f15b6f1869d1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

